### PR TITLE
Fix hard-coded SAMPLERATE

### DIFF
--- a/euphony.js
+++ b/euphony.js
@@ -20,16 +20,16 @@ export var Euphony = (function () {
             AUTHOR: 'Ji-woong Choi'
         };
 
+        this.context = new (window.AudioContext || window.webkitAudioContext)();
+        this.SAMPLERATE = this.context.sampleRate;
         this.BUFFERSIZE = 2048;
         this.PI = 3.141592653589793;
         this.PI2 = this.PI * 2;
-        this.SAMPLERATE = 44100;
         this.SPAN = 86;
         this.BASE_FREQUENCY = 18000;
         this.CHANNEL = 1;
         this.setModulation('CPFSK');
 
-        this.context = new (window.AudioContext || window.webkitAudioContext)();
         this.isAudioWorkletAvailable = Boolean(this.context.audioWorklet && typeof this.context.audioWorklet.addModule === 'function');
         this.STATE = 0;
         this.isPlaying = false;


### PR DESCRIPTION
A glitch sound problem caused by sample rate mismatch in audio devices with a sample rate other than 44100Hz has been fixed.
This code was tested on various audio devices using the Chrome web browser on windows and android.

Co-Authored-By: designe <designe@users.noreply.github.com>
Co-Authored-By: yeonns <yeonns@users.noreply.github.com>
Co-Authored-By: YoungSeokHong <YoungSeokHong@users.noreply.github.com>
Co-Authored-By: ycs1m1yk <ycs1m1yk@users.noreply.github.com>